### PR TITLE
Fixed return types

### DIFF
--- a/src/Forms/Fields/SlugInput.php
+++ b/src/Forms/Fields/SlugInput.php
@@ -43,7 +43,7 @@ class SlugInput extends TextInput
         return $this;
     }
 
-    public function getSlugInputUrlVisitLinkVisible(): ?string
+    public function getSlugInputUrlVisitLinkVisible(): ?bool
     {
         return $this->evaluate($this->slugInputUrlVisitLinkVisible);
     }
@@ -109,7 +109,7 @@ class SlugInput extends TextInput
         return $this;
     }
 
-    public function getReadOnly(): string
+    public function getReadOnly(): bool
     {
         return $this->evaluate($this->readOnly);
     }


### PR DESCRIPTION
Just fixed a couple return types that returned strings even tho the relevant property accepts booleans.