### PR TITLE
Fixed return type for PHP 8.4

### DIFF
--- a/src/Forms/Fields/SlugInput.php
+++ b/src/Forms/Fields/SlugInput.php
@@ -179,7 +179,7 @@ class SlugInput extends TextInput
 
     public function getBaseUrl(): string
     {
-        return Str::of($this->evaluate($this->baseUrl))->rtrim('/');
+        return Str::rtrim($this->evaluate($this->baseUrl), '/');
     }
 
     public function slugInputShowUrl(bool $showUrl): static


### PR DESCRIPTION
The line I changed started throwing an error about the wrong return type when I updated to PHP 8.4. This change fixes that error. 