### PR TITLE
[breaking] fix breaking styles of other filament plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ If needed, you can publish the config file with:
 php artisan vendor:publish --tag="filament-title-with-slug-config"
 ```
 
+You will need to set up a Filament [custom theme](https://filamentphp.com/docs/4.x/styling/overview#creating-a-custom-theme)
+
+If you don't yet have a custom theme, run the following command:
+
+```bash
+php artisan make:filament-theme
+```
+
+Next, open up the theme.css file for the custom theme and add the following line:
+
+```css
+@import "../../../../vendor/blendbyte/filament-title-with-slug/resources/css/filament-title-with-slug.css";
+```
+
 ## Translation
 
 If needed, you can publish the translation files with:

--- a/src/FilamentTitleWithSlugServiceProvider.php
+++ b/src/FilamentTitleWithSlugServiceProvider.php
@@ -2,8 +2,6 @@
 
 namespace Camya\Filament;
 
-use Filament\Support\Assets\Css;
-use Filament\Support\Facades\FilamentAsset;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -16,12 +14,5 @@ class FilamentTitleWithSlugServiceProvider extends PackageServiceProvider
             ->hasConfigFile()
             ->hasViews()
             ->hasTranslations();
-    }
-
-    public function packageBooted(): void
-    {
-        FilamentAsset::register([
-            Css::make('filament-title-with-slug', __DIR__.'/../resources/dist/filament-title-with-slug.css'),
-        ], 'filament-title-with-slug');
     }
 }


### PR DESCRIPTION
I've experienced css issues with other filament plugins that only appeared after adding this plugin to a project. The issue was adding the precompiled FilamentAsset which somehow resulted in overwriting some basic tailwind utility classes.
Adding the css through a Filament Theme fixes the issue although I can't really explain what was happening exactly!

I've added instructions on how to do this and removed loading the precompiled css in the ServiceProvider.